### PR TITLE
add support for capturing on multiple interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ The probe element references a probe configuration file, `probe-iptraffic.xml`.
 That file names the network device where statistics are tallied:
 
 ```XML
-<probe-iptraffic device="eth0"/>
+<probe-iptraffic>
+  <device name="eth0"/>
+  <device name="eth1"/>
+</probe-iptraffic>
+
 ```
 
 ```
@@ -30,9 +34,9 @@ That file names the network device where statistics are tallied:
 otestpoint.iptraffic.capture Measurement_pcap_tables_ipv4_udp v1 212 bytes
 IPTraffic.Tables.IPv4.UDP.node-1
 [] receive 
-|Src        |Dst        |Port |Rx Bytes|Rx Packets|
-|10.10.1.1  |224.252.1.1|10101|81722   |1409      |
-|10.10.2.1  |224.252.1.1|10201|81606   |1407      |
-|10.1.10.100|224.252.1.3|30101|166518  |2871      |
+|Device|Src         |Dst        |Port|Rx Bytes|Rx Packets|
+|eth0  |10.10.1.1  |224.252.1.1|10101|81722   |1409      |
+|eth0  |10.10.2.1  |224.252.1.1|10201|81606   |1407      |
+|eth1  |10.1.10.100|224.252.1.3|30101|166518  |2871      |
 --
 ```

--- a/src/probe.cc
+++ b/src/probe.cc
@@ -57,7 +57,17 @@ namespace
 <xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>\
   <xs:element name='probe-iptraffic'>\
     <xs:complexType>\
-      <xs:attribute name='device' type='xs:string' use='required'/>  \
+      <xs:sequence>\
+        <xs:element name='device' maxOccurs='unbounded' minOccurs='1'>\
+          <xs:complexType>\
+            <xs:simpleContent>\
+              <xs:extension base='xs:string'>\
+                <xs:attribute type='xs:string' name='name' use='required'/>\
+              </xs:extension>\
+            </xs:simpleContent>\
+          </xs:complexType>\
+        </xs:element>\
+      </xs:sequence>\
     </xs:complexType>\
   </xs:element>\
 </xs:schema>";
@@ -66,7 +76,7 @@ namespace
 
 OpenTestPoint::IPTraffic::Probe::Probe(ProbeIndex probeIndex):
   ProbePlugin{probeIndex},
-  pPcapHandle_{}
+  vContexts_{}
 {}
 
 OpenTestPoint::ProbeNames
@@ -117,19 +127,36 @@ OpenTestPoint::IPTraffic::Probe::initialize(const std::string & sConfigurationFi
 
   xmlNodePtr pRoot = xmlDocGetRootElement(pDoc);
 
-  xmlChar * pDeviceName = xmlGetProp(pRoot,BAD_CAST "device");
+  xmlNodePtr pChild = pRoot->xmlChildrenNode;
+  xmlChar * pDeviceName = NULL;
 
-  sDevice_ = reinterpret_cast<const char *>(pDeviceName);
-
-  xmlFree(pDeviceName);
-
+  mutex_.lock();
+  
+  while(pChild != NULL) {
+    if ((!xmlStrcmp(pChild->name, (const xmlChar *)"device"))) {
+      pDeviceName = xmlGetProp(pChild,(const xmlChar *) "name");
+      ProbeContext pc(std::string(reinterpret_cast<const char *>(pDeviceName)));
+      vContexts_.push_back(pc);
+      
+      // lDevices_.push_back(reinterpret_cast<const char *>(pDeviceName));
+      xmlFree(pDeviceName);
+    }
+    pChild = pChild->next;
+    
+  }
+  mutex_.unlock();
+  
   xmlFreeDoc(pDoc);
 
+  // To-Do, check this name is accurate
   probeNames_.push_back("IPTraffic.Tables.IPv4.UDP");
 
-  OPENTESTPOINT_PROBESERVICE_LOG_INFO(pProbeService_,
-                                      "creating IPTraffic probe on %s",
-                                      sDevice_.c_str());
+  for(auto const& context: vContexts_){
+    OPENTESTPOINT_PROBESERVICE_LOG_INFO(pProbeService_,
+            "creating IPTraffic probe on %s",
+            context.sDevice.c_str());
+  }
+  
 
   return probeNames_;
 }
@@ -139,48 +166,67 @@ void OpenTestPoint::IPTraffic::Probe::start()
   char errbuf[PCAP_ERRBUF_SIZE]={};
 
   // open pcap handle
-  if((pPcapHandle_ = pcap_open_live(sDevice_.c_str(),
-                                    PCAP_SNAPLEN,
-                                    PCAP_PROMISC,
-                                    PCAP_TIMEOUT,
-                                    errbuf)) == NULL)
+  for(auto & context: vContexts_){
+    context.mutex.lock();
+    
+    const char* device = context.sDevice.c_str();
+    
+    pcap_t * pPcapHandle = pcap_open_live(device,
+            PCAP_SNAPLEN,
+            PCAP_PROMISC,
+            PCAP_TIMEOUT,
+            errbuf);
+    
+    if(pPcapHandle  == NULL )
     {
       throw Toolkit::Exception{"could not open device:%s %s",
-          sDevice_.c_str(),
+          device,
           errbuf};
     }
+    // no need for an "else" since the if throws
+    context.pPcapHandle=pPcapHandle;
 
-  // set datalink type, this covers 10/100/1000
-  if(pcap_set_datalink(pPcapHandle_, DLT_EN10MB) < 0)
+    // set datalink type, this covers 10/100/1000
+    if(pcap_set_datalink(pPcapHandle, DLT_EN10MB) < 0)
     {
       OPENTESTPOINT_PROBESERVICE_LOG_INFO(pProbeService_,
-                                          "could not set datalink type on device %s %s",
-                                          sDevice_.c_str(),
-                                          errbuf);
+              "could not set datalink type on device %s %s",
+              device,
+              errbuf);
     }
 
-  // currently unsupported by winpcap
-  if(pcap_setdirection(pPcapHandle_, PCAP_D_IN) < 0)
+    // only get inbound data, should probably be a flag on the probe conf
+    // currently unsupported by winpcap
+    if(pcap_setdirection(pPcapHandle, PCAP_D_IN) < 0)
     {
       throw Toolkit::Exception{"could not set direction on device %s %s",
-          sDevice_.c_str(),
+          device,
           errbuf};
     }
+    // unlock it now, so we don't deadlock the thread, we're done with our changes anyway
+    context.mutex.unlock();
+    
+    // start pcap read thread
+    context.thread = std::thread(&Probe::readDevice,this,&context);
 
-  // start pcap read thread
-  thread_ = std::thread(&Probe::readDevice,this);
+  }
+  
 }
 
 void OpenTestPoint::IPTraffic::Probe::stop()
 {
-  if(pPcapHandle_)
-    {
-      pthread_cancel(thread_.native_handle());
-
-      thread_.join();
-
-      pcap_close(pPcapHandle_);
+  for(auto & context: vContexts_){
+    context.mutex.lock();
+    
+    if(context.pPcapHandle){
+      // stop the capture
+      pcap_close(context.pPcapHandle);
+      context.pPcapHandle = NULL;
+      //stop the thread
+      pthread_cancel(context.thread.native_handle());
+      context.thread.join();
     }
+  }
 }
 
 void OpenTestPoint::IPTraffic::Probe::destroy()
@@ -197,19 +243,27 @@ OpenTestPoint::ProbeData OpenTestPoint::IPTraffic::Probe::probe()
 
   auto pReceive = msg.mutable_receive();
 
+  pReceive->add_labels("Device");
   pReceive->add_labels("Src");
   pReceive->add_labels("Dst");
   pReceive->add_labels("Port");
   pReceive->add_labels("Rx Bytes");
   pReceive->add_labels("Rx Packets");
 
-  mutex_.lock();
+  for(auto & context: vContexts_){
+    context.mutex.lock();
 
-  for(const auto & entry : store_)
+    for(const auto & entry : context.store)
     {
       auto pRow = pReceive->add_rows();
 
       auto pValue = pRow->add_values();
+
+      pValue->set_type(OpenTestPoint::MeasurementTable::Measurement::TYPE_STRING);
+
+      pValue->set_svalue(context.sDevice);
+
+      pValue = pRow->add_values();
 
       pValue->set_type(OpenTestPoint::MeasurementTable::Measurement::TYPE_STRING);
 
@@ -249,8 +303,9 @@ OpenTestPoint::ProbeData OpenTestPoint::IPTraffic::Probe::probe()
 
       pValue->set_uvalue(std::get<1>(entry.second));
     }
-
-  mutex_.unlock();
+    context.mutex.unlock();
+  }
+  
 
   std::string sBlob{};
 
@@ -269,7 +324,7 @@ OpenTestPoint::ProbeData OpenTestPoint::IPTraffic::Probe::probe()
 OpenTestPoint::IPTraffic::Probe::~Probe()
 {}
 
-void OpenTestPoint::IPTraffic::Probe::readDevice()
+void OpenTestPoint::IPTraffic::Probe::readDevice(ProbeContext * pc)
 {
   const std::uint8_t * buf = NULL;
 
@@ -277,17 +332,17 @@ void OpenTestPoint::IPTraffic::Probe::readDevice()
 
   int iPcapResult{};
 
-  while(1)
+  while(pc->pPcapHandle)
     {
       // get frame, blocks here
-      iPcapResult = pcap_next_ex(pPcapHandle_, &pcap_hdr, &buf);
+      iPcapResult = pcap_next_ex(pc->pPcapHandle, &pcap_hdr, &buf);
 
       // error
       if(iPcapResult < 0)
         {
           OPENTESTPOINT_PROBESERVICE_LOG_ERROR(pProbeService_,
                                                "pcap_next_ex error %s",
-                                               pcap_geterr(pPcapHandle_));
+                                               pcap_geterr(pc->pPcapHandle));
 
           // done
           break;
@@ -321,13 +376,14 @@ void OpenTestPoint::IPTraffic::Probe::readDevice()
                             reinterpret_cast<const udphdr *>(buf + ETHER_HDR_LEN  + (pIPHeader->ihl*4));
 
 
-                          mutex_.lock();
+                          pc->mutex.lock();
 
-                          auto iter = store_.find(std::make_tuple(pIPHeader->saddr,
-                                                                  pIPHeader->daddr,
-                                                                  pUDPHeader->dest));
+                          auto iter = pc->store.find(std::make_tuple(
+                                    pIPHeader->saddr,
+                                    pIPHeader->daddr,
+                                    pUDPHeader->dest));
 
-                          if(iter != store_.end())
+                          if(iter != pc->store.end())
                             {
                               // bytes
                               std::get<0>(iter->second) += ntohs(pUDPHeader->len);
@@ -337,13 +393,13 @@ void OpenTestPoint::IPTraffic::Probe::readDevice()
                             }
                           else
                             {
-                              store_.insert({std::make_tuple(pIPHeader->saddr,
+                              pc->store.insert({std::make_tuple(pIPHeader->saddr,
                                                              pIPHeader->daddr,
                                                              pUDPHeader->dest),
                                     std::make_tuple(ntohs(pUDPHeader->len),1)});
                             }
 
-                          mutex_.unlock();
+                          pc->mutex.unlock();
 
                           break;
                         }

--- a/src/probe.h
+++ b/src/probe.h
@@ -43,11 +43,15 @@
 #include <mutex>
 #include <map>
 #include <tuple>
+#include <vector>
 
 namespace OpenTestPoint
 {
   namespace IPTraffic
   {
+    
+      
+      
     class Probe : public ProbePlugin
     {
     public:
@@ -65,21 +69,49 @@ namespace OpenTestPoint
 
       ProbeData probe() override;
 
+      class ProbeContext
+      {
+      public:
+        std::string   sDevice;
+        pcap_t *      pPcapHandle = NULL;
+        std::thread   thread;
+        std::mutex    mutex;
+      
+        using Store = std::map<std::tuple<std::uint32_t, //src
+          std::uint32_t, //dst
+          std::uint16_t>, //dport
+          std::tuple<std::uint64_t, //total bytes
+          std::uint64_t>>; //total packets
+        Store store;
+      
+
+      ProbeContext():
+        sDevice{""}
+          {
+          };
+          
+      ProbeContext(const ProbeContext& old):
+          sDevice{old.sDevice},
+          pPcapHandle{old.pPcapHandle}
+//          thread{old.thread}
+            
+          {
+          };
+
+      ProbeContext(std::string name):
+        sDevice{name}
+          {
+          };
+      
+      };
+    
     private:
       ProbeNames probeNames_;
-      pcap_t * pPcapHandle_;
-      std::thread thread_;
+        
       std::mutex mutex_;
-      std::string sDevice_;
+      std::vector<ProbeContext> vContexts_;
 
-      using Store = std::map<std::tuple<std::uint32_t, //src
-                                        std::uint32_t, //dst
-                                        std::uint16_t>, //dport
-                             std::tuple<std::uint64_t, //total bytes
-                                        std::uint64_t>>; //total packets
-      Store store_;
-
-      void readDevice();
+      void readDevice(ProbeContext * pc);
     };
   }
 }


### PR DESCRIPTION
As discussed in #3, I've added support for capturing data on multiple interfaces. This changes the interface for the messages sent, I don't know if there is any additional changes needed when that happens.